### PR TITLE
added `ddev composer install` to the instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ git clone https://github.com/craftcms/europa-museum.git
 cd europa-museum
 ddev start
 ddev craft db/restore seed.sql
+ddev composer install
 ```
 
 As with the vanilla Docker setup process, you can create a user for yourself with the CLI:


### PR DESCRIPTION
`ddev composer install` is necessary to be able to run the demo locally, based on a question and error in the community https://discord.com/channels/456442477667418113/456442477667418115/1410576255966777344

It seems useful to add this comment in the README.md as final step to give a more streamlined experience

### Description



### Related issues

